### PR TITLE
feat: Adding 'SNR' function to onebone.signal

### DIFF
--- a/onebone/signal/__init__.py
+++ b/onebone/signal/__init__.py
@@ -2,6 +2,7 @@ from .envelope import envelope_hilbert
 from .fft import positive_fft
 from .filter import bandpass_filter, bandstop_filter, highpass_filter, lowpass_filter
 from .smoothing import moving_average
+from .snr import snr_feature
 
 __all__ = [
     "lowpass_filter",
@@ -14,4 +15,5 @@ __all__ = [
     "envelope_hilbert",
     "positive_fft",
     "moving_average",
+    "snr_feature",
 ]

--- a/onebone/signal/__init__.py
+++ b/onebone/signal/__init__.py
@@ -2,7 +2,7 @@ from .envelope import envelope_hilbert
 from .fft import positive_fft
 from .filter import bandpass_filter, bandstop_filter, highpass_filter, lowpass_filter
 from .smoothing import moving_average
-from .snr import snr_feature
+from .snr import snr
 
 __all__ = [
     "lowpass_filter",
@@ -15,5 +15,5 @@ __all__ = [
     "envelope_hilbert",
     "positive_fft",
     "moving_average",
-    "snr_feature",
+    "snr",
 ]

--- a/onebone/signal/snr.py
+++ b/onebone/signal/snr.py
@@ -5,7 +5,8 @@ from scipy import signal
 def snr_feature(x: np.ndarray, fs: float) -> np.ndarray:
     """
     Extract the SNR(Signal-to-Noise-Ratio) feature from the signal using the 'STFT'.
-    SNR is the ratio between max power intensity of frequency and power of other frequencies at time t in the STFT spetrum.
+    SNR is the ratio between max power intensity of frequency and power of other frequencies 
+    at time t in the STFT spetrum.
 
     Parameters
     ----------

--- a/onebone/signal/snr.py
+++ b/onebone/signal/snr.py
@@ -5,7 +5,7 @@ from scipy import signal
 def snr_feature(x: np.ndarray, fs: float) -> np.ndarray:
     """
     Extract the SNR(Signal-to-Noise-Ratio) feature from the signal using the 'STFT'.
-    SNR is the ratio between max power intensity of frequency and power of other frequencies 
+    SNR is the ratio between max power intensity of frequency and power of other frequencies
     at time t in the STFT spetrum.
 
     Parameters

--- a/onebone/signal/snr.py
+++ b/onebone/signal/snr.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import signal
 
 
-def snr_feature(x: np.ndarray, fs: float) -> np.ndarray:
+def snr_feature(x: np.ndarray, fs: float, nperseg: int = 256, noverlap: int = 32) -> np.ndarray:
     """
     Extract the SNR(Signal-to-Noise-Ratio) feature from the signal using the 'STFT'.
     SNR is the ratio between max power intensity of frequency and power of other frequencies
@@ -14,6 +14,10 @@ def snr_feature(x: np.ndarray, fs: float) -> np.ndarray:
         Signal data. Must be real.
     fs : float
         Sampling rate.
+    nperseg : int, optional
+        Length of each segment. Default value is 256
+    noverlap : int, optional
+        Number of points to overlap between segments. Default value is 32
 
     Returns
     ----------
@@ -30,7 +34,7 @@ def snr_feature(x: np.ndarray, fs: float) -> np.ndarray:
     Usage
     --------
     1. Get a snr array by using snr_feature for one of given signals
-    2. Get a mean of the snr array
+    2. Make the segments of snr array and get the mean of each segment.
     3. Compare the mean of SNR between normal states and fault states
     e.g. SNR_fault = np.mean(SNR_fault_array), SNR_normal = np.mean(SNR_normal_array)
     4. Typically, SNR_fault is smaller than SNR_normal.
@@ -38,7 +42,7 @@ def snr_feature(x: np.ndarray, fs: float) -> np.ndarray:
     if np.iscomplexobj(x):
         raise ValueError("`x` must be real.")
 
-    f, t, Sxx = signal.spectrogram(x, fs=fs, nperseg=64, noverlap=8)
+    f, t, Sxx = signal.spectrogram(x, fs=fs, nperseg=nperseg, noverlap=noverlap)
     P = np.max(Sxx, axis=0)  # max power intensity over the entire frequency range at time point t
     Res = np.sum(Sxx, axis=0) - P  # noise
     snr = P / Res

--- a/onebone/signal/snr.py
+++ b/onebone/signal/snr.py
@@ -1,28 +1,32 @@
+from typing import Union
+
 import numpy as np
 from scipy import signal
 
 
-def snr_feature(x: np.ndarray, fs: float, nperseg: int = 256, noverlap: int = 32) -> np.ndarray:
+def snr(
+    x: np.ndarray, fs: Union[int, float] = 1000, nperseg: int = 256, noverlap: int = 32
+) -> np.ndarray:
     """
     Extract the SNR(Signal-to-Noise-Ratio) feature from the signal using the 'STFT'.
     SNR is the ratio between max power intensity of frequency and power of other frequencies
-    at time t in the STFT spetrum.
+    at time t in the STFT spectrum.
 
     Parameters
     ----------
-    x : array_like
-        Signal data. Must be real.
-    fs : float
+    x : numpy.ndarray
+        1d-Signal data. Must be real.
+    fs : int or float
         Sampling rate.
-    nperseg : int, optional
-        Length of each segment. Default value is 256
-    noverlap : int, optional
-        Number of points to overlap between segments. Default value is 32
+    nperseg : int, default=256
+        Length of each segment.
+    noverlap : int, default=32
+        Number of points to overlap between segments.
 
     Returns
     ----------
     snr : numpy.ndarray
-        SNR of the `x`, 1d-array
+        SNR of the `x`, 1d-array.
 
     Examples
     --------
@@ -31,7 +35,7 @@ def snr_feature(x: np.ndarray, fs: float, nperseg: int = 256, noverlap: int = 32
     >>> x = 10.0 * np.sin(2 * np.pi * 20.0 * t)
     >>> snr_array = snr_feature(x, fs)
 
-    Usage
+    Notes
     --------
     1. Get a snr array by using snr_feature for one of given signals
     2. Make the segments of snr array and get the mean of each segment.
@@ -39,11 +43,12 @@ def snr_feature(x: np.ndarray, fs: float, nperseg: int = 256, noverlap: int = 32
     e.g. SNR_fault = np.mean(SNR_fault_array), SNR_normal = np.mean(SNR_normal_array)
     4. Typically, SNR_fault is smaller than SNR_normal.
     """
+
     if np.iscomplexobj(x):
         raise ValueError("`x` must be real.")
 
-    f, t, Sxx = signal.spectrogram(x, fs=fs, nperseg=nperseg, noverlap=noverlap)
-    P = np.max(Sxx, axis=0)  # max power intensity over the entire frequency range at time point t
-    Res = np.sum(Sxx, axis=0) - P  # noise
-    snr = P / Res
+    _, _, power = signal.spectrogram(x, fs=fs, nperseg=nperseg, noverlap=noverlap)
+    p = np.max(power, axis=0)  # max power intensity over the entire frequency range at time point t
+    res = np.sum(power, axis=0) - p  # noise
+    snr = p / res
     return snr

--- a/onebone/signal/snr.py
+++ b/onebone/signal/snr.py
@@ -1,0 +1,44 @@
+import numpy as np
+from scipy import signal
+
+
+def snr_feature(x: np.ndarray, fs: float) -> np.ndarray:
+    """
+    Extract the SNR(Signal-to-Noise-Ratio) feature from the signal using the 'STFT'.
+    SNR is the ratio between max power intensity of frequency and power of other frequencies at time t in the STFT spetrum.
+
+    Parameters
+    ----------
+    x : array_like
+        Signal data. Must be real.
+    fs : float
+        Sampling rate.
+
+    Returns
+    ----------
+    snr : numpy.ndarray
+        SNR of the `x`, 1d-array
+
+    Examples
+    --------
+    >>> fs = 1000.0
+    >>> t = np.linspace(0, 1, int(fs))
+    >>> x = 10.0 * np.sin(2 * np.pi * 20.0 * t)
+    >>> snr_array = snr_feature(x, fs)
+
+    Usage
+    --------
+    1. Get a snr array by using snr_feature for one of given signals
+    2. Get a mean of the snr array
+    3. Compare the mean of SNR between normal states and fault states
+    e.g. SNR_fault = np.mean(SNR_fault_array), SNR_normal = np.mean(SNR_normal_array)
+    4. Typically, SNR_fault is smaller than SNR_normal.
+    """
+    if np.iscomplexobj(x):
+        raise ValueError("`x` must be real.")
+
+    f, t, Sxx = signal.spectrogram(x, fs=fs, nperseg=64, noverlap=8)
+    P = np.max(Sxx, axis=0)  # max power intensity over the entire frequency range at time point t
+    Res = np.sum(Sxx, axis=0) - P  # noise
+    snr = P / Res
+    return snr

--- a/tests/signal/test_snr.py
+++ b/tests/signal/test_snr.py
@@ -3,7 +3,7 @@ from typing import Callable
 import numpy as np
 import pytest
 
-from onebone.signal import snr_feature
+from onebone.signal import snr
 
 
 def generate_signal(fs: float):
@@ -16,13 +16,17 @@ def check_bad_args():
     x = np.array([1.0 + 0.0j])
     fs = 1000.0
     with pytest.raises(ValueError) as ex:
-        snr_feature(x, fs)
+        snr(x, fs)
     assert ex.value.args[0] == "`x` must be real."
 
 
-def check_snr(snr_feature: Callable, fs: float, expected_return: np.float64):
+def check_1d_signal(snr: Callable):
+    pass
+
+
+def check_snr(snr: Callable, fs: float, expected_return: np.float64):
     x = generate_signal(fs)
-    snr = snr_feature(x, fs)
+    snr = snr(x, fs)
     output = np.round(np.mean(snr), 2)
     assert np.all(np.equal(output, expected_return)), (
         f"Wrong return: The expected return is {expected_return}, " + f"but output is {output}"
@@ -31,7 +35,7 @@ def check_snr(snr_feature: Callable, fs: float, expected_return: np.float64):
 
 def test_snr():
     check_bad_args()
-    check_snr(snr_feature, 1000.0, 7.16)
+    check_snr(snr, 1000.0, 7.16)
 
 
 if __name__ == "__main__":

--- a/tests/signal/test_snr.py
+++ b/tests/signal/test_snr.py
@@ -31,7 +31,7 @@ def check_snr(snr_feature: Callable, fs: float, expected_return: np.float64):
 
 def test_snr():
     check_bad_args()
-    check_snr(snr_feature, 1000.0, 3.49)
+    check_snr(snr_feature, 1000.0, 7.16)
 
 
 if __name__ == "__main__":

--- a/tests/signal/test_snr.py
+++ b/tests/signal/test_snr.py
@@ -1,0 +1,38 @@
+from typing import Callable
+
+import numpy as np
+import pytest
+
+from onebone.signal import snr_feature
+
+
+def generate_signal(fs: float):
+    t = np.linspace(0, 1, int(fs))
+    x = 10.0 * np.sin(2 * np.pi * 20.0 * t)
+    return x
+
+
+def check_bad_args():
+    x = np.array([1.0 + 0.0j])
+    fs = 1000.0
+    with pytest.raises(ValueError) as ex:
+        snr_feature(x, fs)
+    assert ex.value.args[0] == "`x` must be real."
+
+
+def check_snr(snr_feature: Callable, fs: float, expected_return: np.float64):
+    x = generate_signal(fs)
+    snr = snr_feature(x, fs)
+    output = np.round(np.mean(snr), 2)
+    assert np.all(np.equal(output, expected_return)), (
+        f"Wrong return: The expected return is {expected_return}, " + f"but output is {output}"
+    )
+
+
+def test_snr():
+    check_bad_args()
+    check_snr(snr_feature, 1000.0, 3.49)
+
+
+if __name__ == "__main__":
+    test_snr()


### PR DESCRIPTION
## Summary
_Write the summary about this PR._
SNR(signal to noise ratio) is the ratio of signal to noise power on STFT.
The source of how to calculate SNR is from the paper "High-Accuracy Unsupervised Fault Detection of Industrial Robots Using Current Signal Analysis" published in 2019 IEEE.
link : https://ieeexplore.ieee.org/abstract/document/8819374
 
## Changes
_Write changes in detail._
Add snr_feature function on onebone/signal/__init__.py
Add snr_feature function on onebone/signal
Add test_snr.py for testing snr_feature function


1. Get frequency, time, power of signal by using signal.spectrogram.
2. P = the max power intensity over the entire frequency range at time point t. 
3. Res = (the sum of power intensity over the entire frequency range at time point t) - P
4. SNR = P/Res

## How to Test?
_Write a way to test the changes._
1. Check that SNR_feature can't work on complex signal by using the function 'check_bad_args' in test_snr.py
2. Generate the 1D real signal by using the function 'generate_signal' in test_snr.py.
3. Check that output and expected_return are the same.

## Checklist

- [x] Do you pass all the tests?
- [x] Do you write the changes on document such as README?