### PR TITLE
fix: make clean으로 .pyc가 제대로 지워지지 않는 현상 버그 수정(#89)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ setup:
 	pre-commit install
 
 clean:
-	rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info */.pytest_cache .pytest_cache
+	rm -vrf ./build ./dist ./*.tgz ./*.egg-info */.pytest_cache .pytest_cache
+	python3 -Bc "import pathlib; [p.unlink() for p in pathlib.Path('.').rglob('*.py[co]')]"
+	python3 -Bc "import pathlib; [p.rmdir() for p in pathlib.Path('.').rglob('__pycache__')]"
 
 format:
 	isort .


### PR DESCRIPTION
## Summary
프로젝트 내의 모든 .pyc를 찾지 못하는 현상을 발견하여 Makefile을 수정
OS마다 find 문법이 조금씩 상이하여 어떤 플랫폼에서도 작동할 수 있도록
python으로 구현하였음
링크: https://stackoverflow.com/questions/28991015/python3-project-remove-pycache-folders-and-pyc-files

## Changes
Makefile 수정

## How to Test?
make test 이후 make clean으로 확인

## Checklist

- [v] Do you pass all the tests?
- [v] Do you write the changes on document such as README?